### PR TITLE
Dork to find exposed services

### DIFF
--- a/infohound/tool/dorks/exposed services.txt
+++ b/infohound/tool/dorks/exposed services.txt
@@ -4,3 +4,4 @@ site:<domain> inurl:wp-content | inurl:wp-includes
 intitle:traefik inurl:8080/dashboard "<domain>"
 intitle:"Dashboard [Jenkins]" "<domain>"
 site:<domain> inurl:signup | inurl:register | intitle:Signup
+site:/<doamin>:*/


### PR DESCRIPTION
The dork _site:/example.com:*/_ will find open ports from that domain, which can be useful for analists.